### PR TITLE
Deployment updates

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -4,7 +4,7 @@ const endpoints = require("./api/routes");
 const helmet = require('helmet');
 const cors = require('cors');
 const app = express();
-const port = 3000;
+const port = 8080;
 
 const fifteenMinutes = 15 * 60 * 1000;
 const apiLimiter = rateLimit({

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -17,9 +17,9 @@ resource "aws_cognito_user_pool_client" "client" {
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_flows                  = ["code"] # Use with PKCE (Does not require client secret)
   allowed_oauth_scopes                 = ["email", "openid", "profile"]
-  callback_urls                        = ["http://localhost:5000/callback"]
-  logout_urls                          = ["http://localhost:5000/logout"]
-  supported_identity_providers         = ["COGNITO", "Google"]
+  callback_urls                        = var.callback_urls
+  logout_urls                          = var.logout_urls
+  supported_identity_providers         = ["Google"]
   generate_secret                      = false # Public client cannot store the secret securely, so we won't use one
 
   depends_on = [aws_cognito_identity_provider.google]
@@ -51,6 +51,6 @@ resource "aws_cognito_identity_provider" "google" {
 
   attribute_mapping = {
     email    = "email"
-    username = "sub"
+    username = "username"
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,3 +58,13 @@ variable "client_secret" {
   description = "The client secret for the identity provider."
   sensitive   = true
 }
+
+variable "callback_urls" {
+  type        = list(string)
+  description = "The callback URLs for the identity provider."
+}
+
+variable "logout_urls" {
+  type        = list(string)
+  description = "The logout URLs for the identity provider."
+}


### PR DESCRIPTION
- Changed port of backend so that it will be compatible with elastic beanstalk
- Removed ability to sign up with passwords in cognito, only google is allowed now
- Allowed callbacks to localhost and myplanner.projects.bbdgrad.com from cognito